### PR TITLE
Fixed package resolution for new package search paths

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -128,7 +128,8 @@ static struct piccolo_Package* resolvePackage(struct piccolo_Engine* engine, str
         }
     }
 
-    const char* source = piccolo_readFile(path);
+    // readFile returns a heap buffer - this shouldn't be marked const
+    char* source = piccolo_readFile(path);
     if(source == NULL) {
         for(int i = 0; i < engine->searchPaths.count; i++) {
             piccolo_applyRelativePathToFilePath(path, name, nameLen, engine->searchPaths.values[i]);
@@ -447,6 +448,12 @@ static void findGlobals(struct piccolo_Engine* engine, struct piccolo_Compiler* 
                 findGlobals(engine, compiler, callNode->function);
                 break;
             }
+            // TODO: These should be handled even though they may be error conditions since if someone is using piccolo from native unmanaged code they can create situations like this
+            case PICCOLO_EXPR_LITERAL: break;
+            case PICCOLO_EXPR_VAR: break;
+            case PICCOLO_EXPR_BLOCK: break;
+            case PICCOLO_EXPR_FN_LITERAL: break;
+            case PICCOLO_EXPR_IMPORT: break;
         }
         curr = curr->nextExpr;
     }
@@ -969,6 +976,7 @@ static void compileExpr(struct piccolo_ExprNode* expr, COMPILE_PARAMS) {
             compileHashmapLiteral((struct piccolo_HashmapLiteralNode*)expr, COMPILE_ARGS);
             break;
         }
+        case PICCOLO_EXPR_HASHMAP_ENTRY: break; // TODO: Handle this too
         case PICCOLO_EXPR_SUBSCRIPT: {
             compileSubscript((struct piccolo_SubscriptNode*)expr, COMPILE_ARGS);
             break;

--- a/debug/expr.c
+++ b/debug/expr.c
@@ -50,7 +50,7 @@ void piccolo_printExpr(struct piccolo_ExprNode* expr, int offset) {
         case PICCOLO_EXPR_HASHMAP_LITERAL: {
             struct piccolo_HashmapLiteralNode* hashmap = (struct piccolo_HashmapLiteralNode*)expr;
             printf("HASHMAP\n");
-            piccolo_printExpr(hashmap->first, offset + 1);
+            piccolo_printExpr((struct piccolo_ExprNode*) hashmap->first, offset + 1);
             break;
         }
         case PICCOLO_EXPR_SUBSCRIPT: {

--- a/embedding.c
+++ b/embedding.c
@@ -4,6 +4,11 @@
 #include <string.h>
 
 void piccolo_addSearchPath(struct piccolo_Engine* engine, const char* path) {
+    if(path[strlen(path) - 1] != '/') {
+        // TODO: This should be fixed in the CLI once the package path changes are merged
+        piccolo_enginePrintError(engine, "Incorrectly formatted package path '%s'\n", path);
+        return;
+    }
     piccolo_writeStringArray(engine, &engine->searchPaths, path);
 }
 

--- a/engine.c
+++ b/engine.c
@@ -185,6 +185,10 @@ static piccolo_Value indexing(struct piccolo_Engine* engine, struct piccolo_Obj*
             return PICCOLO_NIL_VAL();
         }
     }
+
+    // This could maybe be marked unreachable since the default case returns but there is no way to handle compiler intrinsic atm.
+    // TODO: Possibly a future compiler_features.h or the like could resolve this kind of thing
+    return PICCOLO_NIL_VAL();
 }
 
 static bool shouldCloseUpval(struct piccolo_Engine* engine, struct piccolo_ObjUpval* upval) {

--- a/gc.c
+++ b/gc.c
@@ -40,7 +40,7 @@ static void markObj(struct piccolo_Obj* obj) {
         }
         case PICCOLO_OBJ_CLOSURE: {
             struct piccolo_ObjClosure* closure = (struct piccolo_ObjClosure*)obj;
-            markObj(closure->prototype);
+            markObj((struct piccolo_Obj*) closure->prototype);
             for(int i = 0; i < closure->upvalCnt; i++) {
                 markObj((struct piccolo_Obj*) closure->upvals[i]);
             }

--- a/stdlib/random.c
+++ b/stdlib/random.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-static piccolo_Value randomValNative(struct piccolo_Engine* engine, int argc, piccolo_Value argv) {
+static piccolo_Value randomValNative(struct piccolo_Engine* engine, int argc, piccolo_Value* /* Was missing pointer in type */ argv) {
     if(argc != 0) {
         piccolo_runtimeError(engine, "Wrong argument count.");
         return PICCOLO_NIL_VAL();

--- a/util/strutil.h
+++ b/util/strutil.h
@@ -5,8 +5,9 @@
 #include <stdint.h>
 
 struct piccolo_strutil_LineInfo {
-    char* lineStart;
-    char* lineEnd;
+    // These are assigned with const values in several places and so should be marked const
+    const char* lineStart;
+    const char* lineEnd;
     int line;
 };
 


### PR DESCRIPTION
Package paths no longer resolve to unbounded file contents.
Package paths no longer fail to contain package names of length 4096 (Missing terminator on path buffer).
Package paths will now error out the engine if not followed by a `/` as required by path concat procs (`piccolo_applyRelativePathToFilePath`).
Failure to resolve a package on the package path will no longer result in a segfault.