### PR TITLE
Fixed more crashes

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -121,7 +121,7 @@ static struct piccolo_Package* resolvePackage(struct piccolo_Engine* engine, str
         }
     }
 
-    char path[4096 + 1 /* Terminator */] = { 0 };
+    char path[PICCOLO_MAX_PACKAGE + 1 /* Terminator */] = { 0 };
     piccolo_applyRelativePathToFilePath(path, name, nameLen, sourceFilepath);
     for(int i = 0; i < engine->packages.count; i++) {
         if(strcmp(path, engine->packages.values[i]->packageName) == 0) {

--- a/compiler.h
+++ b/compiler.h
@@ -7,6 +7,9 @@
 #include "scanner.h"
 #include "util/dynarray.h"
 
+// Maximum length of a package name
+#define PICCOLO_MAX_PACKAGE 4096
+
 struct piccolo_Engine;
 struct piccolo_Package;
 

--- a/parser.c
+++ b/parser.c
@@ -322,6 +322,9 @@ static struct piccolo_ExprNode* parseImport(PARSER_PARAMS) {
     if(parser->currToken.type == PICCOLO_TOKEN_IMPORT) {
         advanceParser(engine, parser);
         if(parser->currToken.type == PICCOLO_TOKEN_STRING) {
+            if(parser->currToken.length > PICCOLO_MAX_PACKAGE) {
+                parsingError(engine, parser, "Package import of length %d exceeded PICCOLO_MAX_PACKAGE (%d).", parser->currToken.length, PICCOLO_MAX_PACKAGE);
+            }
             struct piccolo_Token packageName = parser->currToken;
             struct piccolo_ImportNode* import = ALLOCATE_NODE(parser, Import, PICCOLO_EXPR_IMPORT);
             import->packageName = packageName;


### PR DESCRIPTION
- Fixed 4096 import bug with a check in the parser for import strings exceeding `PICCOLO_MAX_PACKAGE` (now defined in [compiler.h](https://github.com/PiccoloLang/piccolo/compare/main...Th3T3chn0G1t:crashes?expand=1#diff-5994f8f3ec8ebae24f389c905b024c00ae9ba32b5cfdf4d975e0950fd1174f15))
- Fixed bad callframe crash by adding validity checks to `run` in [engine.c](https://github.com/PiccoloLang/piccolo/compare/main...Th3T3chn0G1t:crashes?expand=1#diff-034c6a1c95ba40b233d4aa439d13f78fb4c1734ab54112c57189d7b9214acb5d)