### PR TITLE
C++ and Windows support hopefully

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -205,7 +205,7 @@ struct piccolo_VarData piccolo_getVariable(struct piccolo_Engine* engine, struct
                 result.slot = upvalueSlot;
                 result.setOp = PICCOLO_OP_SET_UPVAL;
                 result.getOp = PICCOLO_OP_GET_UPVAL;
-                result.mutable = compiler->upvals.values[upvalueSlot].Mutable;
+                result.Mutable = compiler->upvals.values[upvalueSlot].Mutable;
                 result.decl = compiler->upvals.values[upvalueSlot].decl;
                 result.decl = NULL;
             }
@@ -213,14 +213,14 @@ struct piccolo_VarData piccolo_getVariable(struct piccolo_Engine* engine, struct
             result.slot = localSlot;
             result.getOp = PICCOLO_OP_GET_LOCAL;
             result.setOp = PICCOLO_OP_SET_LOCAL;
-            result.mutable = compiler->locals.values[localSlot].Mutable;
+            result.Mutable = compiler->locals.values[localSlot].Mutable;
             result.decl = compiler->locals.values[localSlot].decl;
         }
     } else {
         result.slot = globalSlot;
         result.getOp = PICCOLO_OP_GET_GLOBAL;
         result.setOp = PICCOLO_OP_SET_GLOBAL;
-        result.mutable = compiler->globals->values[globalSlot].Mutable;
+        result.Mutable = compiler->globals->values[globalSlot].Mutable;
         result.decl = compiler->globals->values[globalSlot].decl;
     }
 
@@ -442,7 +442,7 @@ static void findGlobals(struct piccolo_Engine* engine, struct piccolo_Compiler* 
                     piccolo_compilationError(engine, compiler, varDecl->name.charIdx, "Variable '%.*s' already defined.", varDecl->name.length, varDecl->name.start);
                 } else {
                     struct piccolo_Variable var = createVar(varDecl->name, compiler->globals->count);
-                    var.Mutable = varDecl->mutable;
+                    var.Mutable = varDecl->Mutable;
                     var.decl = varDecl;
                     piccolo_writeVariableArray(engine, compiler->globals, var);
                 }
@@ -761,7 +761,7 @@ static void compileVarDecl(struct piccolo_VarDeclNode* varDecl, COMPILE_PARAMS) 
         } else {
             int slot = compiler->locals.count;
             struct piccolo_Variable var = createVar(varDecl->name, slot);
-            var.Mutable = varDecl->mutable;
+            var.Mutable = varDecl->Mutable;
             var.decl = varDecl;
             piccolo_writeVariableArray(engine, &compiler->locals, var);
             piccolo_writeBytecode(engine, bytecode, PICCOLO_OP_PUSH_LOCAL, 0);
@@ -781,7 +781,7 @@ static void compileVarSet(struct piccolo_VarSetNode* varSet, COMPILE_PARAMS) {
         piccolo_compilationError(engine, compiler, varSet->name.charIdx, "Variable '%.*s' is not defined.", varSet->name.length, varSet->name.start);
     } else {
         varSet->decl = varData.decl;
-        if(!varData.mutable) {
+        if(!varData.Mutable) {
             piccolo_compilationError(engine, compiler, varSet->name.charIdx, "Cannot modify immutable variable.");
             return;
         }

--- a/compiler.h
+++ b/compiler.h
@@ -35,7 +35,7 @@ struct piccolo_VarData {
     int slot;
     enum piccolo_OpCode setOp;
     enum piccolo_OpCode getOp;
-    bool mutable;
+    bool Mutable;
     struct piccolo_VarDeclNode* decl;
 };
 

--- a/engine.c
+++ b/engine.c
@@ -203,7 +203,7 @@ static piccolo_Value indexing(struct piccolo_Engine* engine, struct piccolo_Obj*
             if(nativeStruct->index != NULL) {
                 return nativeStruct->index(PICCOLO_GET_PAYLOAD(nativeStruct, void), engine, idx, set, value);
             } else {
-                piccolo_runtimeError(engine, "Cannot index %s", nativeStruct->typename);
+                piccolo_runtimeError(engine, "Cannot index %s", nativeStruct->Typename);
             }
             break;
         }

--- a/object.c
+++ b/object.c
@@ -59,13 +59,13 @@ struct piccolo_Obj* allocateObj(struct piccolo_Engine* engine, enum piccolo_ObjT
     return obj;
 }
 
-struct piccolo_ObjNativeStruct* piccolo_allocNativeStruct(struct piccolo_Engine* engine, size_t size, const char* typename) {
+struct piccolo_ObjNativeStruct* piccolo_allocNativeStruct(struct piccolo_Engine* engine, size_t size, const char* Typename) {
     struct piccolo_ObjNativeStruct* nativeStruct = (struct piccolo_ObjNativeStruct*)allocateObj(engine, PICCOLO_OBJ_NATIVE_STRUCT, sizeof(struct piccolo_ObjNativeStruct) + size);
     nativeStruct->payloadSize = size;
     nativeStruct->free = NULL;
     nativeStruct->gcMark = NULL;
     nativeStruct->index = NULL;
-    nativeStruct->typename = typename;
+    nativeStruct->Typename = Typename;
     return nativeStruct;
 }
 

--- a/object.h
+++ b/object.h
@@ -87,7 +87,7 @@ struct piccolo_ObjNativeStruct {
     void (*free)(void* payload);
     void (*gcMark)(void* payload);
     piccolo_Value (*index)(void* payload, struct piccolo_Engine* engine, piccolo_Value key, bool set, piccolo_Value value);
-    const char* typename;
+    const char* Typename;
     size_t payloadSize;
 };
 

--- a/parser.c
+++ b/parser.c
@@ -344,7 +344,7 @@ static struct piccolo_ExprNode* parseImport(PARSER_PARAMS) {
                 }
                 advanceParser(engine, parser);
                 importAs->value = (struct piccolo_ExprNode*)import;
-                importAs->mutable = false;
+                importAs->Mutable = false;
                 return (struct piccolo_ExprNode*)importAs;
             }
             return (struct piccolo_ExprNode*)import;
@@ -648,7 +648,7 @@ static struct piccolo_ExprNode* parseVarDecl(PARSER_PARAMS) {
     SKIP_NEWLINES()
     if(parser->currToken.type == PICCOLO_TOKEN_VAR || parser->currToken.type == PICCOLO_TOKEN_CONST) {
         struct piccolo_VarDeclNode* varDecl = ALLOCATE_NODE(parser, VarDecl, PICCOLO_EXPR_VAR_DECL);
-        varDecl->mutable = parser->currToken.type == PICCOLO_TOKEN_VAR;
+        varDecl->Mutable = parser->currToken.type == PICCOLO_TOKEN_VAR;
         advanceParser(engine, parser);
         if(parser->currToken.type == PICCOLO_TOKEN_IDENTIFIER) {
             varDecl->name = parser->currToken;

--- a/parser.h
+++ b/parser.h
@@ -118,7 +118,7 @@ struct piccolo_VarDeclNode {
     struct piccolo_Token name;
     struct piccolo_ExprNode* value;
     bool typed;
-    bool mutable;
+    bool Mutable;
 };
 
 struct piccolo_VarSetNode {

--- a/stdlib/dll.c
+++ b/stdlib/dll.c
@@ -121,16 +121,16 @@ static piccolo_Value openNative(struct piccolo_Engine* engine, int argc, piccolo
 
 #ifdef _WIN32
     dll->library = LoadLibrary(path);
-    if(dll->handle == NULL) {
+    if(dll->library == NULL) {
         size_t pathLen = strlen(path);
         char buf[4096];
         for(int i = 0; i < engine->searchPaths.count; i++) {
             piccolo_applyRelativePathToFilePath(buf, path, pathLen, engine->searchPaths.values[i]);
-            dll->handle = LoadLibrary(buf);
-            if(dll->handle != NULL)
+            dll->library = LoadLibrary(buf);
+            if(dll->library != NULL)
                 break;
         }
-        if(dll->handle == NULL) {
+        if(dll->library == NULL) {
             piccolo_runtimeError(engine, "Could not open DLL.");
             return PICCOLO_NIL_VAL();
         }

--- a/value.c
+++ b/value.c
@@ -65,7 +65,7 @@ static void printObject(struct piccolo_Obj* obj) {
     }
     if(obj->type == PICCOLO_OBJ_NATIVE_STRUCT) {
         struct piccolo_ObjNativeStruct* nativeStruct = (struct piccolo_ObjNativeStruct*)obj;
-        printf("<%s>", nativeStruct->typename);
+        printf("<%s>", nativeStruct->Typename);
     }
     obj->printed = false;
 }


### PR DESCRIPTION
Pls don't use C++ keywords in variable names my guy :>
Also why is there a difference between Windows and Unix shared library handles, where on windows the variable is called `library` whilst on unix it's called `handle`.